### PR TITLE
replacing deprecated julia_pkgdir() with Pkg.dir()

### DIFF
--- a/src/sprofile.jl
+++ b/src/sprofile.jl
@@ -4,7 +4,7 @@ using OptionsMod
 
 ## Wrap the C library
 fnames = ["libprofile.so", "libprofile.dylib", "libprofile.dll"]
-paths = [pwd(), joinpath(julia_pkgdir(), "Profile", "deps")]
+paths = [pwd(), joinpath(Pkg.dir(), "Profile", "deps")]
 global libname
 found = false
 for path in paths


### PR DESCRIPTION
triggered by this message:

julia> require("Profile")
WARNING: julia_pkgdir is deprecated, use :(Pkg.dir) instead.

cheers,

rene
