### PR TITLE
Deprecated Warnings & Type Errors

### DIFF
--- a/src/iprofile.jl
+++ b/src/iprofile.jl
@@ -42,7 +42,7 @@ function isfuncexpr(ex::LineNumberNode)
     return false
 end
 function isfuncexpr(ex::Expr)
-    return ex.head == :function || (ex.head == :(=) && ex.args[1].head == :call)
+    return ex.head == :function || (ex.head == :(=) && typeof(ex.args[1]) == Expr && ex.args[1].head == :call)
 end
 
 # Get the "full syntax" of the function call

--- a/test/iprofile.jl
+++ b/test/iprofile.jl
@@ -22,6 +22,8 @@ end
 function f1{T}(x::T)
     return x+5
 end
+
+unused_top_level_var = 2
 end #@iprofile begin
 
 f1(7)


### PR DESCRIPTION
I was initially stumped by why the below test case generated an error, so I fixed the warnings emitted and then traced it to a chunk of code which assumed that this expression was a function declaration in disguise.

> @iprofile begin
> a = 2
> end

While the fix for the actual problem here was straightforward, the only guarantees I offer on the expr->Expr conversion is that looks right and the included test case functions as expected.
