### PR TITLE
Set bytes(%) to 0.0 if total bytes allocated is 0

### DIFF
--- a/src/IProfile.jl
+++ b/src/IProfile.jl
@@ -323,7 +323,7 @@ function profile_print(tc)
                 @printf("%8d  %5.2f  %9.6f  %5.2f  %8d  %s\n", counters[j],
                         100*(comp_time/ttotal),
                         comp_time*1e-9,
-                        100*(byters[j]/btotal),
+                        btotal > 0.0? 100*(byters[j]/btotal) : 0.0,
                         byters[j] / 1e3,
                         show_unquoted(PROFILE_TAGS[i][j]))
             end


### PR DESCRIPTION
Previously, bytes(%) showed up as NaN if total bytes allocated was 0.  This confused me because I thought it was unlikely that my code was allocating nothing so something weird must have been happening. I think 0.0 is a better default, because as [Calvin](http://www.gocomics.com/calvinandhobbes/1995/04/27) says, "if your numbers go ~~up~~ down, it means you're having more fun."
